### PR TITLE
Redirect to the page that requested login via `login_required` decorator

### DIFF
--- a/byceps/static/behavior/login.js
+++ b/byceps/static/behavior/login.js
@@ -20,6 +20,17 @@ onDomReady(() => {
             return;
           }
 
+          // extract 'next' parameter from location.search, if available
+          const searchObject = new URLSearchParams(location.search);
+          const nextParam = searchObject.get('next');
+          if (nextParam !== null) {
+            const nextLocation = new URL(nextParam, location.href);
+            if (nextLocation.hostname == location.hostname) {
+              location.href = nextLocation.pathname;
+              return;
+            }
+          }
+
           // Redirect to location specified via header.
           const redirectUrl = response.headers.get('Location');
           if (redirectUrl !== null) {
@@ -27,14 +38,8 @@ onDomReady(() => {
             return;
           }
 
-          // Redirect to referrer if available.
-          const referrer = document.createElement('a');
-          referrer.href = document.referrer;
-          // Exclude selected referrer paths.
-          if (/^\/(authentication|consent)\//.test(referrer.pathname)) {
-            referrer.pathname = '/';
-          }
-          location.href = (referrer.hostname == location.hostname) ? referrer.pathname : '/';
+          // fallback: redirect to /
+          location.href = '/';
         });
     });
   }

--- a/byceps/util/views.py
+++ b/byceps/util/views.py
@@ -17,6 +17,7 @@ from flask import (
     g,
     jsonify,
     redirect,
+    request,
     Response,
     stream_with_context,
     url_for,
@@ -36,9 +37,9 @@ def login_required(func):
             flash_notice(gettext('Please log in.'))
 
             if g.app_mode.is_admin():
-                return redirect_to('authn_login_admin.log_in_form')
+                return redirect_to('authn_login_admin.log_in_form', next=request.full_path)
             else:
-                return redirect_to('authn_login.log_in_form')
+                return redirect_to('authn_login.log_in_form', next=request.full_path)
         return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Pass original location of the requested url in the query parameter "next", if the login_required decorator redirects to the login view.
Redirect to the previous page after successful login instead of the user's dashboard.