### PR TITLE
Remove usage of `docker-compose` in favor of `docker compose`

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -72,7 +72,7 @@ services:
 secrets:
   secret_key:
     # To generate a secret key file, run:
-    # `docker-compose run --rm byceps-admin byceps generate-secret-key > ./secret_key.txt`
+    # `docker compose run --rm byceps-admin byceps generate-secret-key > ./secret_key.txt`
     file: ./secret_key.txt
 
 volumes:

--- a/docs/installation_docker/index.rst
+++ b/docs/installation_docker/index.rst
@@ -6,11 +6,15 @@ As an alternative to :doc:`installing directly on a system
 </installation/index>`, BYCEPS can be run from Docker_ containers,
 orchestrated by `Docker compose`_.
 
+.. important:: This guide assumes you are using Docker Compose V2, which can be installed with the Docker engine.
+    See `Dockers guide`_ on how to install
+
 Since there is no official Docker image for BYCEPS at this point, you
 have to build one yourself.
 
 .. _Docker: https://www.docker.com/
 .. _Docker Compose: https://docs.docker.com/compose/
+.. _Dockers guide: https://docs.docker.com/engine/install/
 
 First, clone BYCEPS' Git repository to your machine:
 

--- a/docs/installation_docker/index.rst
+++ b/docs/installation_docker/index.rst
@@ -6,8 +6,7 @@ As an alternative to :doc:`installing directly on a system
 </installation/index>`, BYCEPS can be run from Docker_ containers,
 orchestrated by `Docker compose`_.
 
-.. important:: This guide assumes you are using Docker Compose V2, which can be installed with the Docker engine.
-    See `Dockers guide`_ on how to install
+.. important:: This guide assumes you are using Docker Compose V2. If you are still using V1, replace ``docker compose`` with ``docker-compose`` before running commands that include it.
 
 Since there is no official Docker image for BYCEPS at this point, you
 have to build one yourself.

--- a/docs/installation_docker/index.rst
+++ b/docs/installation_docker/index.rst
@@ -13,7 +13,6 @@ have to build one yourself.
 
 .. _Docker: https://www.docker.com/
 .. _Docker Compose: https://docs.docker.com/compose/
-.. _Dockers guide: https://docs.docker.com/engine/install/
 
 First, clone BYCEPS' Git repository to your machine:
 

--- a/docs/installation_docker/index.rst
+++ b/docs/installation_docker/index.rst
@@ -28,7 +28,7 @@ take a few minutes.
 
 .. code-block:: sh
 
-    $ docker-compose up --no-start
+    $ docker compose up --no-start
 
 Then generate a *secret key* and put it in a file Docker Compose is
 configured to pick up as a secret_:
@@ -37,26 +37,26 @@ configured to pick up as a secret_:
 
 .. code-block:: sh
 
-    $ docker-compose run --rm byceps-admin byceps generate-secret-key > ./secret_key.txt
+    $ docker compose run --rm byceps-admin byceps generate-secret-key > ./secret_key.txt
 
 Now create and initially populate the relational database structure:
 
 .. code-block:: sh
 
-    $ docker-compose run --rm byceps-admin byceps initialize-database
+    $ docker compose run --rm byceps-admin byceps initialize-database
 
 Optionally, insert demonstration data to get a feel for how BYCEPS set
 up with a party, a party site, etc. looks like:
 
 .. code-block:: sh
 
-    $ docker-compose run --rm byceps-admin byceps create-demo-data
+    $ docker compose run --rm byceps-admin byceps create-demo-data
 
 To spin up the application:
 
 .. code-block:: sh
 
-    $ docker-compose up
+    $ docker compose up
 
 The admin frontend should now be available at http://localhost:8081/.
 Log in with user ``DemoAdmin`` and password ``demodemo``.


### PR DESCRIPTION
This pr solves #15, with the change of `docker-compose` to `docker compose` in the documentation.

This does not touch GitHub Actions, as this would require more testing, but changing this might be a very good idea, as there is a risk of it breaking one day without warning.