### PR TITLE
fix: gallery hidden checkbox required and gallery creation error

### DIFF
--- a/byceps/blueprints/admin/gallery/forms.py
+++ b/byceps/blueprints/admin/gallery/forms.py
@@ -18,7 +18,7 @@ from byceps.util.l10n import LocalizedForm
 class GalleryCreateForm(LocalizedForm):
     slug = StringField(lazy_gettext('Slug'), [InputRequired()])
     title = StringField(lazy_gettext('Title'), [InputRequired()])
-    hidden = BooleanField(lazy_gettext('hidden'), [InputRequired()])
+    hidden = BooleanField(lazy_gettext('hidden'), [])
 
     def __init__(self, brand_id: BrandID, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/byceps/blueprints/admin/gallery/forms.py
+++ b/byceps/blueprints/admin/gallery/forms.py
@@ -18,7 +18,7 @@ from byceps.util.l10n import LocalizedForm
 class GalleryCreateForm(LocalizedForm):
     slug = StringField(lazy_gettext('Slug'), [InputRequired()])
     title = StringField(lazy_gettext('Title'), [InputRequired()])
-    hidden = BooleanField(lazy_gettext('hidden'), [])
+    hidden = BooleanField(lazy_gettext('hidden'))
 
     def __init__(self, brand_id: BrandID, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/byceps/services/gallery/gallery_service.py
+++ b/byceps/services/gallery/gallery_service.py
@@ -28,7 +28,7 @@ def create_gallery(
     hidden: bool,
 ) -> Gallery:
     """Create a gallery."""
-    db_brand = brand_service._get_db_brand(brand_id)
+    db_brand = brand_service._find_db_brand(brand_id)
     if db_brand is None:
         raise ValueError(f'Unknown brand ID "{brand_id}"')
 


### PR DESCRIPTION
This pr fixes a bug with the gallery requiring the "hidden" checkbox to be checked.  
The pr in the same swing fixes the issue, where adding a gallery caused an internal server error, due to the misuse of `_get_db_brand`, as it should be `_find_db_brand`.