### PR TITLE
Switch byceps data directory to bind to local folder instead of volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ __pycache__
 .mypy_cache
 
 # user data
-/data
+/data/*
+!/data/.gitkeep
 
 # documentation
 /docs/_build

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 x-byceps-base: &byceps-base
   build: .
   volumes:
-    - byceps-data:/home/byceps/data:rw
+    - ./data:/home/byceps/data:rw
   depends_on:
     - db
     - redis
@@ -91,7 +91,6 @@ secrets:
     file: ./secret_key.txt
 
 volumes:
-  byceps-data:
   db-data:
 
 networks:


### PR DESCRIPTION
This switches the docker compose to bind the data directory to a local folder, instead of docker volume.

This *can* be a breaking change for existing systems, but [data can be copied from the volume, into the new data directory](https://stackoverflow.com/questions/35406213/how-to-copy-data-from-docker-volume-to-host).

Using a bound directory as a volume, instead of a Docker volume, makes sense in this case, as data is added manually.  
Much the same as with the `/sites` directory.  
Therefore, this aligns how data is handled across the `/sites` and `/data` directories.

As a sidenote, the data directory have also been added to git, in order to ensure it keeps the current user permissions.  
If it is not created, when the docker compose system spins up the stack, it will create a folder, but with Docker engine permission. This will in most standard install be *root*. Therefore, the directory would afterwards have to have its permissions changed. Which is a hassle.  
I have ensured, that all files in the `/data` directory is untracked, ensuring no developer data is accidentally added.  
However, this behavior might wanted changed, if it comes to light, that data wants to be git tracked.